### PR TITLE
Remove auto-camelcasing of contact properties

### DIFF
--- a/lib/r_hapi/contact.rb
+++ b/lib/r_hapi/contact.rb
@@ -192,9 +192,8 @@ module RHapi
     # Instance methods -------------------------------------------------------
     # Work with data in the data hash
     def method_missing(method, *args, &block)
-      
-      attribute = ActiveSupport::Inflector.camelize(method.to_s, false)
-  
+      attribute = method.to_s
+
       if attribute =~ /=$/ # Define property -- does not have to exist
         attribute = attribute.chop
         self.changed_attributes[attribute] = args[0]


### PR DESCRIPTION
Hi guys --

Thanks for merging the last one!  We've run into an issue with Contacts.  Sending a contact property seems to automatically camelcase the property name.  This is at odds with the Hubspot validations on contact properties, which does not allow you to make a property with any capital letters, and pretty much makes creating a contact impossible.

```
"status"=>"error", 
"message"=>"[{
              "property":"hsPersona",
              "msg":"Property "hsPersona" does not exist",
              "error":"PROPERTY_DOESNT_EXIST"
              }]"
```

Also, we started down the path of updating the specs to reflect this change, but a lot of specs are currently failing.  It looks like 188881a changed how `Connection#url_for` works, and the specs haven't yet been updated.
