### PR TITLE
Remove warning when bundle install

### DIFF
--- a/r_hapi.gemspec
+++ b/r_hapi.gemspec
@@ -55,9 +55,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_development_dependency(%q<jeweler>, [">= 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<curb>, ["~> 0.7.12"])
-      s.add_runtime_dependency(%q<json>, [">= 1.5.1"])
-      s.add_runtime_dependency(%q<activesupport>, [">= 0"])
     else
       s.add_dependency(%q<curb>, ["~> 0.7.12"])
       s.add_dependency(%q<json>, [">= 1.5.1"])
@@ -66,9 +63,6 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_dependency(%q<jeweler>, [">= 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<curb>, ["~> 0.7.12"])
-      s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<activesupport>, [">= 0"])
     end
   else
     s.add_dependency(%q<curb>, ["~> 0.7.12"])
@@ -78,9 +72,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<bundler>, [">= 1.0.0"])
     s.add_dependency(%q<jeweler>, [">= 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<curb>, ["~> 0.7.12"])
-    s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<activesupport>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
There are some duplicated dependencies in the r_hapi.gemspec, so whenever you try to bundle install it in a project with Gemfile, the following warning message will appear:

```
r_hapi at /Users/oscar/.rvm/gems/ruby-2.1.3/bundler/gems/rHAPI-b06fafc37fdf did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on curb (~> 0.7.12), (~> 0.7.12) use:
    add_runtime_dependency 'curb', '~> 0.7.12', '~> 0.7.12'
```

This PR remove the duplicates (and fix the warning).
